### PR TITLE
feat: Dockerize the chat bubble application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY backend/requirements.txt /app/requirements.txt
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the backend directory contents into the container at /app/backend
+COPY ./backend /app/backend
+
+# Make port 8000 available to the world outside this container
+EXPOSE 8000
+
+# Define environment variable (optional, for information)
+ENV NAME ChatBubbleBackend
+
+# Run app.py when the container launches
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chat with Bubbles Demo
 
-This project demonstrates a simple web-based chat interface where user interactions can lead to a series of predefined options presented as clickable bubbles. It uses a Python FastAPI backend and an HTML/JavaScript/D3.js frontend.
+This project demonstrates a simple web-based chat interface where user interactions can lead to a series of predefined options presented as clickable bubbles. It uses a Python FastAPI backend and an HTML/JavaScript/D3.js frontend. The backend can be run using Docker.
 
 ## Features
 
@@ -8,80 +8,127 @@ This project demonstrates a simple web-based chat interface where user interacti
 *   Receive responses as clickable bubbles.
 *   Clicking a bubble sends its associated payload as a new message to the backend, triggering further responses.
 *   Simple conversational flow based on predefined backend logic.
+*   Backend containerization using Docker and Docker Compose.
 
 ## Project Structure
 
 ```
 .
 ├── backend/
-│   └── main.py       # FastAPI application
+│   ├── main.py             # FastAPI application
+│   └── requirements.txt    # Python dependencies
 ├── frontend/
-│   ├── index.html    # Main HTML file for the chat interface
-│   ├── app.js        # JavaScript logic for frontend interactions and D3.js bubble rendering
-│   └── style.css     # CSS for styling the chat interface
-└── README.md         # This file
+│   ├── index.html          # Main HTML file for the chat interface
+│   ├── app.js              # JavaScript logic for frontend interactions and D3.js bubble rendering
+│   └── style.css           # CSS for styling the chat interface
+├── Dockerfile              # Dockerfile for building the backend image
+├── docker-compose.yml      # Docker Compose file for managing the backend service
+└── README.md               # This file
 ```
 
 ## Setup and Running
 
-### 1. Backend (FastAPI)
+There are two main ways to run this application:
+
+1.  **Running Backend Natively + Frontend in Browser (Original Method)**
+2.  **Running Backend with Docker + Frontend in Browser**
+
+---
+
+### 1. Running Backend Natively + Frontend in Browser
+
+**Backend (FastAPI):**
 
 **Prerequisites:**
 *   Python 3.7+
 *   pip (Python package installer)
 
 **Installation:**
-
 Navigate to the project's root directory in your terminal.
-
 1.  **Create a virtual environment (recommended):**
     ```bash
     python -m venv venv
     source venv/bin/activate  # On Windows: venv\Scripts\activate
     ```
-
-2.  **Install dependencies:**
+2.  **Install dependencies from `backend/requirements.txt`:**
     ```bash
-    pip install fastapi uvicorn[standard] pydantic
+    pip install -r backend/requirements.txt
     ```
 
 **Running the Backend:**
-
 From the project's root directory, run:
 ```bash
 uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 ```
-*   `--reload`: Enables auto-reload when code changes.
-*   `--host 0.0.0.0`: Makes the server accessible on your network (useful if testing from another device or VM).
-*   `--port 8000`: Specifies the port. The frontend `app.js` expects the backend to be on this port.
+*   The backend API will be available at `http://127.0.0.1:8000`.
+*   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
 
-The backend API will be available at `http://127.0.0.1:8000`. You can see the OpenAPI documentation at `http://127.0.0.1:8000/docs`.
-
-### 2. Frontend (HTML, JS, D3.js)
+**Frontend (HTML, JS, D3.js):**
 
 **Prerequisites:**
-*   A modern web browser that supports HTML5, JavaScript (ES6+), and D3.js.
+*   A modern web browser.
 
 **Running the Frontend:**
-
-1.  Ensure the backend server is running (see step above).
+1.  Ensure the backend server (native or Docker) is running and accessible on port 8000.
 2.  Open the `frontend/index.html` file directly in your web browser.
-    *   You can usually do this by right-clicking the file in your file explorer and choosing "Open with" and selecting your browser, or by typing the file path into your browser's address bar (e.g., `file:///path/to/your/project/frontend/index.html`).
 
-## How it Works
+---
 
-1.  The user types a message in the input field and clicks "Send" (or presses Enter).
-2.  The JavaScript in `frontend/app.js` captures this message.
-3.  It displays the user's message in the chat log.
-4.  It sends the message to the `/chat` endpoint of the FastAPI backend (running on `http://127.0.0.1:8000`).
-5.  The backend (`backend/main.py`) processes the message:
-    *   If the message is "hello" (case-insensitive), it returns a specific set of bubble options.
-    *   Otherwise, it returns a default set of bubble options.
-6.  The frontend JavaScript receives the JSON response containing the bubbles.
-7.  D3.js is used to render these bubbles dynamically in the `#bubble-container`.
-8.  If the user clicks on a bubble:
-    *   The text of the bubble is displayed as a new user message in the chat log.
-    *   The `payload` associated with that bubble is sent as a new message to the backend.
-    *   The process repeats from step 5, allowing for a continued "conversation."
+### 2. Running Backend with Docker + Frontend in Browser
+
+**Prerequisites:**
+*   Docker Desktop or Docker Engine installed and running.
+
+**Option A: Using Docker Compose (Recommended)**
+
+1.  **Build and Run:**
+    Navigate to the project's root directory (where `docker-compose.yml` is located) and run:
+    ```bash
+    docker-compose up --build
+    ```
+    *   `--build` ensures the image is built if it doesn't exist or if `Dockerfile` changed.
+    *   To run in detached mode (in the background), use `docker-compose up -d --build`.
+
+2.  **Accessing the Backend:**
+    *   The backend API will be available at `http://127.0.0.1:8000`.
+    *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
+
+3.  **Stopping:**
+    *   If running in the foreground, press `Ctrl+C`.
+    *   If running in detached mode, use `docker-compose down`.
+
+**Option B: Using Docker CLI Directly**
+
+1.  **Build the Docker Image:**
+    Navigate to the project's root directory (where `Dockerfile` is located) and run:
+    ```bash
+    docker build -t chat-bubble-backend .
+    ```
+    *   `chat-bubble-backend` is the tag (name) for your image.
+
+2.  **Run the Docker Container:**
+    ```bash
+    docker run -p 8000:8000 --name chat-bubble-container chat-bubble-backend
+    ```
+    *   `-p 8000:8000`: Maps port 8000 of the container to port 8000 on your host machine.
+    *   `--name chat-bubble-container`: Assigns a name to your running container for easier management.
+    *   To run in detached mode: `docker run -d -p 8000:8000 --name chat-bubble-container chat-bubble-backend`
+
+3.  **Accessing the Backend:**
+    *   As above, the backend will be on `http://127.0.0.1:8000`.
+
+4.  **Stopping and Removing the Container:**
+    *   If running in foreground: `Ctrl+C`.
+    *   To stop: `docker stop chat-bubble-container`.
+    *   To remove: `docker rm chat-bubble-container`.
+
+**Frontend:**
+*   Regardless of how the backend is run with Docker, the frontend (`frontend/index.html`) is still opened directly in your web browser as described in the "Running Backend Natively" section. It will connect to `http://127.0.0.1:8000`.
+
+---
+
+## How it Works (Summary)
+
+The frontend (`app.js`) sends user messages to the backend's `/chat` endpoint. The backend (`main.py`) processes these and returns bubble options. D3.js renders these bubbles. Clicking a bubble sends its payload back to the backend.
 
 EOF

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+pydantic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      # Mounts the backend code into the container for development.
+      # Uvicorn's --reload flag would pick up changes automatically.
+      # Note: The default CMD in Dockerfile doesn't use --reload.
+      # For development with live reload, you might override the command:
+      # command: ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+      - ./backend:/app/backend
+    environment:
+      # Example of environment variables if your app used them
+      # - SETTING_KEY=VALUE
+      - PYTHONUNBUFFERED=1 # Ensures print statements and logs are sent straight to the console
+
+networks:
+  default:
+    driver: bridge


### PR DESCRIPTION
This commit introduces Docker support for the backend service.

Key changes:
- Added `backend/requirements.txt` to list Python dependencies.
- Created a `Dockerfile` in the root directory to build a container image for the FastAPI backend.
- Added `docker-compose.yml` for easier local development and management of the backend service.
- Significantly updated `README.md` to include:
    - Detailed instructions for building and running the backend using Docker (both via Docker CLI and Docker Compose).
    - Revised project structure.
    - Clarified instructions for running the application natively versus with Docker.

The frontend remains a set of static files (`frontend/`) to be opened directly in a browser, which will now connect to the Dockerized backend.