### PR TITLE
fix: Add root endpoint to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ From the project's root directory, run:
 uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 ```
 *   The backend API will be available at `http://127.0.0.1:8000`.
+    *   A root endpoint `/` provides a welcome message.
 *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
 
 **Frontend (HTML, JS, D3.js):**
@@ -91,6 +92,7 @@ uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 
 2.  **Accessing the Backend:**
     *   The backend API will be available at `http://127.0.0.1:8000`.
+        *   A root endpoint `/` provides a welcome message.
     *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
 
 3.  **Stopping:**
@@ -116,6 +118,7 @@ uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 
 3.  **Accessing the Backend:**
     *   As above, the backend will be on `http://127.0.0.1:8000`.
+        *   A root endpoint `/` provides a welcome message.
 
 4.  **Stopping and Removing the Container:**
     *   If running in foreground: `Ctrl+C`.
@@ -129,6 +132,10 @@ uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 
 ## How it Works (Summary)
 
-The frontend (`app.js`) sends user messages to the backend's `/chat` endpoint. The backend (`main.py`) processes these and returns bubble options. D3.js renders these bubbles. Clicking a bubble sends its payload back to the backend.
+The backend (`main.py`) defines two endpoints:
+*   `/` (GET): Returns a welcome message and API information.
+*   `/chat` (POST): Accepts a user message, processes it, and returns a list of bubble options.
+
+The frontend (`app.js`) sends user messages to the backend's `/chat` endpoint. D3.js renders the returned bubbles. Clicking a bubble sends its payload back to the backend.
 
 EOF

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,17 @@ from typing import List, Dict, Any
 
 app = FastAPI()
 
+# Root endpoint
+@app.get("/")
+async def read_root():
+    return {
+        "message": "Welcome to the Chat Bubble Backend!",
+        "description": "This API powers a chat interface with dynamic bubble responses.",
+        "usage_note": "The main chat functionality is at the /chat (POST) endpoint.",
+        "documentation_url": "/docs",
+        "openapi_url": "/openapi.json"
+    }
+
 class ChatMessage(BaseModel):
     message: str
 


### PR DESCRIPTION
Added a GET endpoint for the root path (/) of the FastAPI application. This endpoint returns a JSON response with a welcome message, API description, and links to the documentation, providing a more informative response for requests to the base URL.

The README.md has also been updated to reflect this new endpoint.