### PR TITLE
fix: Add CORS middleware to backend for frontend communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project demonstrates a simple web-based chat interface where user interacti
 *   Clicking a bubble sends its associated payload as a new message to the backend, triggering further responses.
 *   Simple conversational flow based on predefined backend logic.
 *   Backend containerization using Docker and Docker Compose.
+*   CORS (Cross-Origin Resource Sharing) enabled for easy local development with `file://` origins and standard HTTP origins.
 
 ## Project Structure
 
@@ -28,16 +29,13 @@ This project demonstrates a simple web-based chat interface where user interacti
 
 ## Setup and Running
 
-There are two main ways to run this application:
+This application consists of a backend service and a frontend user interface.
 
-1.  **Running Backend Natively + Frontend in Browser (Original Method)**
-2.  **Running Backend with Docker + Frontend in Browser**
+### Backend Setup & Execution
 
----
+You can run the backend either natively using Python or using Docker.
 
-### 1. Running Backend Natively + Frontend in Browser
-
-**Backend (FastAPI):**
+#### Method 1: Running Backend Natively (Python)
 
 **Prerequisites:**
 *   Python 3.7+
@@ -55,78 +53,70 @@ Navigate to the project's root directory in your terminal.
     pip install -r backend/requirements.txt
     ```
 
-**Running the Backend:**
+**Running the Native Backend:**
 From the project's root directory, run:
 ```bash
 uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 ```
 *   The backend API will be available at `http://127.0.0.1:8000`.
-    *   A root endpoint `/` provides a welcome message.
 *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
+*   The root endpoint `http://127.0.0.1:8000/` provides basic API information.
 
-**Frontend (HTML, JS, D3.js):**
-
-**Prerequisites:**
-*   A modern web browser.
-
-**Running the Frontend:**
-1.  Ensure the backend server (native or Docker) is running and accessible on port 8000.
-2.  Open the `frontend/index.html` file directly in your web browser.
-
----
-
-### 2. Running Backend with Docker + Frontend in Browser
+#### Method 2: Running Backend with Docker
 
 **Prerequisites:**
 *   Docker Desktop or Docker Engine installed and running.
 
 **Option A: Using Docker Compose (Recommended)**
-
 1.  **Build and Run:**
     Navigate to the project's root directory (where `docker-compose.yml` is located) and run:
     ```bash
     docker-compose up --build
     ```
-    *   `--build` ensures the image is built if it doesn't exist or if `Dockerfile` changed.
-    *   To run in detached mode (in the background), use `docker-compose up -d --build`.
-
-2.  **Accessing the Backend:**
-    *   The backend API will be available at `http://127.0.0.1:8000`.
-        *   A root endpoint `/` provides a welcome message.
+    *   `--build` ensures the image is built (or rebuilt if changes like Dockerfile modifications occurred).
+    *   To run in detached mode (background), add the `-d` flag: `docker-compose up -d --build`.
+2.  **Accessing the Backend:** The backend API will be available at `http://127.0.0.1:8000`.
+    *   The root endpoint `/` provides a welcome message.
     *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
-
 3.  **Stopping:**
-    *   If running in the foreground, press `Ctrl+C`.
-    *   If running in detached mode, use `docker-compose down`.
+    *   If running in the foreground (`Ctrl+C` to interrupt), then `docker-compose down` to stop and remove containers/networks.
+    *   If in detached mode, just `docker-compose down`.
 
 **Option B: Using Docker CLI Directly**
-
 1.  **Build the Docker Image:**
-    Navigate to the project's root directory (where `Dockerfile` is located) and run:
+    Navigate to the project's root directory (where `Dockerfile` is located):
     ```bash
     docker build -t chat-bubble-backend .
     ```
-    *   `chat-bubble-backend` is the tag (name) for your image.
-
 2.  **Run the Docker Container:**
     ```bash
-    docker run -p 8000:8000 --name chat-bubble-container chat-bubble-backend
+    docker run -d -p 8000:8000 --name chat-bubble-container chat-bubble-backend
     ```
-    *   `-p 8000:8000`: Maps port 8000 of the container to port 8000 on your host machine.
-    *   `--name chat-bubble-container`: Assigns a name to your running container for easier management.
-    *   To run in detached mode: `docker run -d -p 8000:8000 --name chat-bubble-container chat-bubble-backend`
+    *   `-d` runs in detached mode. Remove for foreground mode.
+3.  **Accessing the Backend:** The backend API will be available at `http://127.0.0.1:8000`.
+    *   The root endpoint `/` provides a welcome message.
+    *   OpenAPI documentation: `http://127.0.0.1:8000/docs`.
+4.  **Stopping:**
+    *   `docker stop chat-bubble-container` (if named)
+    *   `docker rm chat-bubble-container` (to remove)
 
-3.  **Accessing the Backend:**
-    *   As above, the backend will be on `http://127.0.0.1:8000`.
-        *   A root endpoint `/` provides a welcome message.
+---
 
-4.  **Stopping and Removing the Container:**
-    *   If running in foreground: `Ctrl+C`.
-    *   To stop: `docker stop chat-bubble-container`.
-    *   To remove: `docker rm chat-bubble-container`.
+### Frontend Usage
 
-**Frontend:**
-*   Regardless of how the backend is run with Docker, the frontend (`frontend/index.html`) is still opened directly in your web browser as described in the "Running Backend Natively" section. It will connect to `http://127.0.0.1:8000`.
+Once the backend service is running (using either Method 1 or Method 2 above and accessible on `http://127.0.0.1:8000`):
+
+1.  **Prerequisite:** A modern web browser (e.g., Chrome, Firefox, Safari, Edge).
+2.  **Open the Frontend:**
+    *   Navigate to the `frontend` directory within the project using your computer's file explorer.
+    *   Locate the `index.html` file.
+    *   Open `index.html` in your web browser. You can typically do this by:
+        *   Double-clicking the `index.html` file.
+        *   Right-clicking on `index.html` and selecting "Open with..." and choosing your browser.
+        *   Dragging the `index.html` file into an open browser window.
+        *   Using your browser's "File" > "Open File..." (or similar) menu option and navigating to `frontend/index.html`.
+
+The chat application should now be visible and interactive in your browser, communicating with the backend.
 
 ---
 
@@ -135,6 +125,7 @@ uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 The backend (`main.py`) defines two endpoints:
 *   `/` (GET): Returns a welcome message and API information.
 *   `/chat` (POST): Accepts a user message, processes it, and returns a list of bubble options.
+It also includes CORS (Cross-Origin Resource Sharing) middleware to allow requests from the frontend (especially when opened as a local `file://` HTML file) to communicate with the backend server.
 
 The frontend (`app.js`) sends user messages to the backend's `/chat` endpoint. D3.js renders the returned bubbles. Clicking a bubble sends its payload back to the backend.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,25 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware # Added
 from pydantic import BaseModel
 from typing import List, Dict, Any
 
 app = FastAPI()
+
+# Add CORS middleware
+origins = [
+    "null",  # Allow file:// origin (for local index.html)
+    "http://localhost", # Common for local dev
+    "http://127.0.0.1", # Common for local dev
+    # Add other origins if needed, e.g., a frontend dev server port
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins, # Or use ["*"] for a public API, but specific is better
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "OPTIONS"], # OPTIONS is important for preflight requests
+    allow_headers=["*"] # Or specify headers like ["Content-Type"]
+)
 
 # Root endpoint
 @app.get("/")


### PR DESCRIPTION
I've implemented CORS (Cross-Origin Resource Sharing) middleware in the FastAPI application (`backend/main.py`). This should resolve issues where your frontend, particularly when opened as a local file (`file://` origin), was blocked from making requests to the backend API due to browser security policies.

The CORS configuration allows specified origins (including "null" for local files, localhost, and 127.0.0.1) to interact with the API.

I've also updated your README.md to reflect the inclusion and necessity of this middleware.