### PR TITLE
feat: Integrate streaming news bubbles

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,17 @@ class BubbleOption(BaseModel):
 class ChatResponse(BaseModel):
     bubbles: List[BubbleOption]
 
+class NewsItem(BaseModel):
+    title: str
+    url: str
+
+# Prepare sample news data
+sample_news_data: List[NewsItem] = []
+for i in range(1, 1001):
+    sample_news_data.append(
+        NewsItem(title=f"Sample News Title {i}", url=f"http://example.com/news/{i}")
+    )
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(chat_message: ChatMessage):
     message = chat_message.message.lower()
@@ -57,6 +68,10 @@ async def chat_endpoint(chat_message: ChatMessage):
             BubbleOption(text="Default Option 2", payload="default_2")
         ]
     return ChatResponse(bubbles=bubbles)
+
+@app.get("/api/news_stream", response_model=List[NewsItem])
+async def get_news_stream():
+    return sample_news_data
 
 # To run this app (from the root directory of the project):
 # uvicorn backend.main:app --reload

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2,6 +2,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const bubbleHolder = document.querySelector('#chat-container .bubble-holder');
     const backendUrl = 'http://127.0.0.1:8000/chat'; // Assuming default FastAPI port
 
+    const newsBackendUrl = 'http://127.0.0.1:8000/api/news_stream'; // New backend URL
+    let allNewsItems = []; // To store all 1000 news items
+    let currentNewsIndex = 0; // To keep track of which news to display next
+    const NEWS_FETCH_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds
+    const NEWS_DISPLAY_INTERVAL = 30 * 1000; // 30 seconds in milliseconds
+    const NEWS_ITEMS_PER_BATCH = 10; // Number of news items to display each time
+
     function renderBubbles(bubbles) {
         // Clear previous dynamic bubbles
         bubbleHolder.querySelectorAll('.dynamic-bubble').forEach(el => el.remove());
@@ -69,6 +76,82 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    // Initial greeting or prompt
-    sendMessageToServer("initial_greeting"); // To get initial bubbles
+    async function fetchNews() {
+        console.log("Fetching news...");
+        try {
+            const response = await fetch(newsBackendUrl);
+            if (!response.ok) {
+                console.error('Error fetching news:', response.status, await response.text());
+                // Potentially display an error to the user, but for now, just log.
+                return;
+            }
+            const data = await response.json();
+            allNewsItems = data; // Store all fetched news items
+            currentNewsIndex = 0; // Reset index when new news is fetched
+            console.log(`Fetched ${allNewsItems.length} news items.`);
+            displayNewsBubbles(); // Display immediately after fetch
+        } catch (error) {
+            console.error('Failed to fetch or parse news:', error);
+        }
+    }
+
+    function displayNewsBubbles() {
+        if (allNewsItems.length === 0) {
+            console.log("No news items to display.");
+            return;
+        }
+
+        // Clear previous news bubbles
+        bubbleHolder.querySelectorAll('.news-item-bubble').forEach(el => el.remove());
+
+        console.log(`Displaying news bubbles, starting from index ${currentNewsIndex}`);
+        const newsBatch = [];
+        for (let i = 0; i < NEWS_ITEMS_PER_BATCH; i++) {
+            if (allNewsItems.length === 0) break; // Should not happen if initial check passes
+            newsBatch.push(allNewsItems[currentNewsIndex % allNewsItems.length]);
+            currentNewsIndex++; // Move to next news item, will wrap around thanks to modulo
+        }
+        // If currentNewsIndex became very large, bring it back to prevent potential overflow issues with very long runs
+        if (allNewsItems.length > 0) { // only if allNewsItems is not empty
+            currentNewsIndex %= allNewsItems.length;
+        }
+
+
+        newsBatch.forEach((newsItem, index) => {
+            const newsBubbleContainer = document.createElement('div');
+            // Assign classes for structure and animation. Add 'news-item-bubble' for specific management.
+            // Use a cycling index for some variation based on existing bubble styles (e.g., bubble-4 to bubble-8 are small)
+            const styleBaseIndex = 4 + (index % 5); // Cycles through 4, 5, 6, 7, 8 for class name
+            newsBubbleContainer.className = `bubble-${styleBaseIndex} bubble-container bubble-animation-x news-item-bubble`;
+
+            const innerBubble = document.createElement('div');
+            innerBubble.className = 'bubble-small bubble-animation-y'; // Assuming all news bubbles are small
+            innerBubble.textContent = newsItem.title; // Display news title
+
+            newsBubbleContainer.appendChild(innerBubble);
+
+            // Customize position and animation to differentiate from interactive bubbles and each other
+            newsBubbleContainer.style.left = `${(index * 15 + 5) % 80}%`; 
+            newsBubbleContainer.style.animationDelay = `${(index * 0.4 + 0.5)}s`; 
+            innerBubble.style.animationDelay = `${(index * 0.3 + 0.2)}s`; 
+
+            // Optional: Open news URL on click
+            // newsBubbleContainer.addEventListener('click', () => { window.open(newsItem.url, '_blank'); });
+
+            bubbleHolder.appendChild(newsBubbleContainer);
+        });
+        console.log(`Displayed ${newsBatch.length} news items.`);
+    }
+
+    // Initial greeting or prompt for interactive bubbles
+    sendMessageToServer("initial_greeting"); 
+
+    // Initial fetch of news
+    fetchNews();
+
+    // Set interval to fetch news every 10 minutes
+    setInterval(fetchNews, NEWS_FETCH_INTERVAL);
+
+    // Set interval to display news bubbles every 30 seconds
+    setInterval(displayNewsBubbles, NEWS_DISPLAY_INTERVAL);
 });


### PR DESCRIPTION
Implements a new feature to display streaming news titles as animated bubbles, alongside the existing interactive bubble functionality.

Backend (`backend/main.py`):
- Added a new Pydantic model `NewsItem` (title, url).
- Created a new API endpoint `/api/news_stream`.
- This endpoint serves a static list of 1000 sample news items.

Frontend (`frontend/app.js`):
- Added constants for news fetching interval (10 mins), display interval (30 secs), and batch size (10 items).
- Implemented `fetchNews()` function to retrieve news from `/api/news_stream` and store them in `allNewsItems`. This function is called on page load and then every 10 minutes.
- Implemented `displayNewsBubbles()` function:
    - Called every 30 seconds.
    - Clears previously shown news bubbles (class `news-item-bubble`).
    - Takes the next batch of 10 news items from `allNewsItems` (cycling through the list).
    - Renders each news item's title in an animated bubble, styled similarly to existing dynamic bubbles.
    - These news bubbles are for display and do not have click interaction to send payloads (though clicking to open URL is a future possibility).
- The `fetchNews` function now calls `displayNewsBubbles` once immediately after a successful fetch to show the first batch of news without waiting for the first 30-second interval.

No significant HTML or CSS changes were made in this iteration, as news bubbles reuse existing styles and are managed dynamically by JavaScript. The `news-item-bubble` class was added for JS lifecycle management.